### PR TITLE
Update target frameworks and package dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     with:
       publishToNuget: ${{ github.event.inputs.publishToNuget == true }}
       dotnet-version: |
-        8.0.x
         9.0.x
+        10.0.x
     secrets:
       NUGETPACKAGEIDENTIFIER: ${{ secrets.NUGETPACKAGEIDENTIFIER }}
       NUGETAPIKEY: ${{ secrets.NUGETAPIKEY }}

--- a/src/OpenXMLSDK.Engine/OpenXMLSDK.Engine.csproj
+++ b/src/OpenXMLSDK.Engine/OpenXMLSDK.Engine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <ProjectGuid>{5D8107A4-0B23-48B0-921C-1EACCDCD70AD}</ProjectGuid>
-	<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>OpenXMLSDK.Engine</PackageId>
     <Authors>MACK Mathieu</Authors>
@@ -37,7 +37,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
     <PackageReference Include="LazZiya.ImageResize" Version="4.1.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup> 

--- a/src/OpenXMLSDK.Engine/OpenXMLSDK.Engine.csproj
+++ b/src/OpenXMLSDK.Engine/OpenXMLSDK.Engine.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
     <PackageReference Include="LazZiya.ImageResize" Version="4.1.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup> 
 
 </Project>

--- a/src/OpenXMLSDK.UnitTest/OpenXMLSDK.UnitTest.csproj
+++ b/src/OpenXMLSDK.UnitTest/OpenXMLSDK.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net9.0</TargetFrameworks>
+	<TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated `TargetFrameworks` in `OpenXMLSDK.Engine.csproj` to replace `net8.0` with `net10.0` and in `OpenXMLSDK.UnitTest.csproj` to replace `net9.0` with `net10.0` for compatibility with the latest .NET versions.

Upgraded `DocumentFormat.OpenXml` in `OpenXMLSDK.Engine.csproj` from version `3.2.0` to `3.3.0`.

Updated test-related dependencies in `OpenXMLSDK.UnitTest.csproj`:
- `Microsoft.NET.Test.Sdk` to `17.14.1`
- `MSTest.TestAdapter` to `3.10.4`
- `MSTest.TestFramework` to `3.10.4`

Resolves #254